### PR TITLE
Fix PHP7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-20.04]
-        php: ['8.0', '8.1']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
 
     name: P${{ matrix.php }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-20.04]
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.3', '7.4', '8.0', '8.1']
 
     name: P${{ matrix.php }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-20.04]
-        php: ['7.3', '7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1']
 
     name: P${{ matrix.php }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.0.1] - TBC
 
 * Fix: Spelling mistake in template caused bug with justified items [PR #5](https://github.com/mikebarlow/megaphone/pull/5)
+* Fix: Added support for PHP7.4 [PR #13](https://github.com/mikebarlow/megaphone/pull/13)
 
 ## [1.0.0] - 2022-09-19
 

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
         }
     ],
     "require": {
+        "php": "^7.3 || ^8.0",
         "livewire/livewire": "^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",
         "pestphp/pest-plugin-livewire": "^1.0",
-        "orchestra/testbench": "^7.7",
+        "orchestra/testbench": "^6.0",
         "pestphp/pest-plugin-faker": "^1.0",
         "spatie/pest-plugin-test-time": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "squizlabs/php_codesniffer": "^3.7",
         "pestphp/pest-plugin-livewire": "^1.0",
         "orchestra/testbench": "^6.0",
-        "pestphp/pest-plugin-faker": "^1.0",
-        "spatie/pest-plugin-test-time": "^1.1"
+        "pestphp/pest-plugin-faker": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "livewire/livewire": "^2.0"
     },
     "require-dev": {

--- a/src/Livewire/Megaphone.php
+++ b/src/Livewire/Megaphone.php
@@ -29,7 +29,7 @@ class Megaphone extends Component
     {
         $this->unread = $this->announcements = collect([]);
 
-        if ($user === null || $user::class !== config('megaphone.model')) {
+        if ($user === null || get_class($user) !== config('megaphone.model')) {
             return;
         }
 

--- a/tests/ConsoleClearNotificationsTest.php
+++ b/tests/ConsoleClearNotificationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use function Spatie\PestPluginTestTime\testTime;
+use Carbon\Carbon;
 
 it('can render clear out old notifications', function () {
     $user = $this->createTestUser();
@@ -12,7 +12,9 @@ it('can render clear out old notifications', function () {
     $this->assertDatabaseCount('notifications', 1);
     $user->unreadNotifications->markAsRead();
 
-    testTime()->addWeeks(3);
+    Carbon::setTestNow(
+        Carbon::now()->addWeeks(3)
+    );
 
     $this->artisan('megaphone:clear-announcements')->assertSuccessful();
 
@@ -29,7 +31,9 @@ it('wont clear newer read notification', function () {
     $this->assertDatabaseCount('notifications', 1);
     $user->unreadNotifications->markAsRead();
 
-    testTime()->addWeeks(1);
+    Carbon::setTestNow(
+        Carbon::now()->addWeeks(1)
+    );
 
     $this->artisan('megaphone:clear-announcements')->assertSuccessful();
 
@@ -45,7 +49,9 @@ it('wont clear unread notification', function () {
     );
     $this->assertDatabaseCount('notifications', 1);
 
-    testTime()->addWeeks(3);
+    Carbon::setTestNow(
+        Carbon::now()->addWeeks(3)
+    );
 
     $this->artisan('megaphone:clear-announcements')->assertSuccessful();
 


### PR DESCRIPTION
I'd originally only supported PHP8 but it seems there's still a market for PHP7 support so this PR will introduce PHP7.4 support to Megaphone.

Fixes #11 