### PR TITLE
Update public user property to be more generic

### DIFF
--- a/src/Livewire/Megaphone.php
+++ b/src/Livewire/Megaphone.php
@@ -8,7 +8,7 @@ use Livewire\Component;
 
 class Megaphone extends Component
 {
-    public $user;
+    public $notifiable_id;
 
     public $announcements;
 
@@ -23,20 +23,26 @@ class Megaphone extends Component
 
     public function mount(Request $request)
     {
-        $this->user = $request->user();
-        $this->loadAnnouncements($this->user);
+        $this->notifiable_id = $request->user()->id ?? null;
+        $notifiable = $this->getNotifiable();
+        $this->loadAnnouncements($notifiable);
         $this->showCount = config('megaphone.showCount', true);
     }
 
-    public function loadAnnouncements($user)
+    public function getNotifiable()
+    {
+        return config('megaphone.model')::find($this->notifiable_id);
+    }
+
+    public function loadAnnouncements($notifiable)
     {
         $this->unread = $this->announcements = collect([]);
 
-        if ($user === null || get_class($user) !== config('megaphone.model')) {
+        if ($notifiable === null || get_class($notifiable) !== config('megaphone.model')) {
             return;
         }
 
-        $announcements = $user->announcements()->get();
+        $announcements = $notifiable->announcements()->get();
         $this->unread = $announcements->whereNull('read_at');
         $this->announcements = $announcements->whereNotNull('read_at');
     }
@@ -49,6 +55,6 @@ class Megaphone extends Component
     public function markAsRead(DatabaseNotification $notification)
     {
         $notification->markAsRead();
-        $this->loadAnnouncements($this->user);
+        $this->loadAnnouncements($this->getNotifiable());
     }
 }

--- a/src/Livewire/Megaphone.php
+++ b/src/Livewire/Megaphone.php
@@ -8,8 +8,6 @@ use Livewire\Component;
 
 class Megaphone extends Component
 {
-    public $notifiable_id;
-
     public $announcements;
 
     public $unread;
@@ -21,17 +19,15 @@ class Megaphone extends Component
         'announcements' => 'required',
     ];
 
-    public function mount(Request $request)
+    public function mount()
     {
-        $this->notifiable_id = $request->user()->id ?? null;
-        $notifiable = $this->getNotifiable();
-        $this->loadAnnouncements($notifiable);
+        $this->loadAnnouncements($this->getNotifiable());
         $this->showCount = config('megaphone.showCount', true);
     }
 
     public function getNotifiable()
     {
-        return config('megaphone.model')::find($this->notifiable_id);
+        return config('megaphone.model')::find(request()->user()->id ?? null);
     }
 
     public function loadAnnouncements($notifiable)


### PR DESCRIPTION
## Reason
This addresses security concerns in Issue #20 whereby the public property `$user` would be available to the client due to Livewire serializing all public properties. Since private and protected properties do not persist between Livewire updates, the suggested fix of setting the `$user` property as private would not work for this situation.

## Updates
The proposed changes remove references to $user and replaces it with a more generic $notifiable. The public property has also been updated to only be the $notifiable_id  (not the entire model). This limits the potential exposure of information to the client side and also removes the User model from the `dataMeta` object in the response payload from livewire. 

## Testing
These changes were tested using PHP 7.4 and PHP 8.1 with the current test suite as no additional tests were required.