### PR TITLE
Removing use of user model in public property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2023-02-25
+
+* Removed `public $user` from component and changed loading of announcements to prevent user model data exposure. [PR #22](https://github.com/mikebarlow/megaphone/pull/22)
+* Added ability to pass in the notifiableId via component render
+
 ## [1.1.0] - 2022-12-27
 
 * Improvement: New SVG Bell Icon [PR #17](https://github.com/mikebarlow/megaphone/pull/17)

--- a/README.md
+++ b/README.md
@@ -229,6 +229,22 @@ This will clear any "read" Megaphone notifications older than 2 weeks old. This 
 
 The 2-week time limit for old notifications is controlled via the Megaphone config file, `config('megaphone.clearAfter')`. So should you wish to alter this cut off point, simply change this value to either extend or shorten the cut off.
 
+## Changing Notifiable Model
+
+Because notifications can be attached to any model via the `Notifiable` trait, Megaphone too can be attached to any model providing the model also has the `Notifiable` trait attached.
+
+As default, Megaphone assumes you will be attaching it to the standard Laravel User model and when loading notifications, it will attempt to retrieve the ID of the logged in user from the Request object.
+
+If you are wanting to attach Megaphone to a Team model for example, change the `model` attribute of the published megaphone config file, `megaphone.php`.
+
+When rendering the Megaphone component, you will then need to pass in the ID of the notifiable model into the component so Megaphone can load the correct notifications
+
+```html
+<livewire:megaphone :notifiableId="$user->team->id"></livewire:megaphone>
+```
+
+
+
 ## Testing
 
 If you wish to run the tests, clone out the repository


### PR DESCRIPTION
The goal here was to remove the use of the User model within the public properties. The bulk of this is taken from the initial PR work (#21 ) from @pjkellar but with some tweaks.

The tweaks are on the basis that, technically Megaphone and Laravel notifications could be attached to something other than a user modal (i.e. a Team). So the tweaks are to allow a $notifiableId to be passed into the component from the view, then only if that is not passed in, will it then simply fallback to the logged in user.

Put this in draft for now as I want to perform some more tests and update the documentation to reflect this change.

Fixes #20 