### PR TITLE
Ensure the popout is always on top

### DIFF
--- a/resources/views/megaphone.blade.php
+++ b/resources/views/megaphone.blade.php
@@ -1,6 +1,8 @@
 <div class="megaphone">
     <div class="relative w-12 h-12" x-data="{ open: false }">
         @include('megaphone::icon')
-        @include('megaphone::popout')
+        @teleport('body')
+            @include('megaphone::popout')
+        @endteleport
     </div>
 </div>


### PR DESCRIPTION
This fixes a bug where if your navbar is a fixed navbar the popout goes under the body and becomes invisible.

Livewire v3 introduced @teleport that fixes the problem conveniently.

https://livewire.laravel.com/docs/teleport