### PR TITLE
Fixed the bug where occasionally the notification popout appears under the body

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,18 +254,36 @@ The 2-week time limit for old notifications is controlled via the Megaphone conf
 
 ## Changing Notifiable Model
 
-Because notifications can be attached to any model via the `Notifiable` trait, Megaphone too can be attached to any model providing the model also has the `Notifiable` trait attached.
+Because notifications can be attached to any model via the `Notifiable` trait, Megaphone too can be attached to any model providing the model also has the `Notifiable` and `HasMegaphoneTrait` trait attached.
 
-As default, Megaphone assumes you will be attaching it to the standard Laravel User model and when loading notifications, it will attempt to retrieve the ID of the logged in user from the Request object.
-
-If you are wanting to attach Megaphone to a Team model for example, change the `model` attribute of the published megaphone config file, `megaphone.php`.
-
-When rendering the Megaphone component, you will then need to pass in the ID of the notifiable model into the component so Megaphone can load the correct notifications
+When rendering the Megaphone component, you will then need to pass in an instance of the notifiable model into the component so Megaphone can load the correct notifications
 
 ```html
-<livewire:megaphone :notifiableId="$user->team->id"></livewire:megaphone>
+<livewire:megaphone :notifiable="$user->team"></livewire:megaphone>
 ```
 
+Here we are passing in the `team` model from the `$user` model. This means Megaphone will load all notifications attached to the `team` model.
+
+However, note that if the $notifiable model is not the currently authenticated user (which it is by default if it's ), you will need to set the authorization rule for the user to view the notifications. This can be done by setting the rule in a Gate or Policy.
+
+```php
+Gate::define('access-notifications', function ($user, Team $team) {
+    return $user->belongsToTeam($team);
+});
+```
+
+If you are using a Policy, you will also need to register the policy in the `AuthServiceProvider` class.
+
+https://laravel.com/docs/10.x/authorization
+
+You can also set the name of the authorization rule in the Megaphone config file, by default it is `access-notifications`.
+
+```php
+    /*
+     * The authorization rule to use when checking if a user can view, modify, mark as read the notifications for a notifiable model.
+     */
+    'access-notifications-permission-name' => 'access-notifications',
+```
 
 
 ## Testing

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "livewire/livewire": "^3.0.1"
+        "livewire/livewire": "^3.0.1",
+        "wireui/heroicons": "^2.4.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",

--- a/config/megaphone.php
+++ b/config/megaphone.php
@@ -1,10 +1,11 @@
 <?php
 
 return [
-    /*
-     * Model that has the "Notifiable" and "HasMegaphone" Traits
+
+    /**
+     * The name of the permission to check against when determining if a model can access another model's notifications
      */
-    'model' => \App\Models\User::class,
+    'access-notifications-permission-name' => 'access notifications',
 
     /*
      * Array of all the notification types to display in Megaphone

--- a/config/megaphone.php
+++ b/config/megaphone.php
@@ -46,4 +46,25 @@ return [
      * show a dot instead
      */
     'showCount' => true,
+
+    /**
+     * Default whether to poll for new notifications
+     */
+    'defaultPolling' => true,
+
+    /**
+     * Default how often to poll for new notifications in milliseconds
+     */
+    'defaultPollInterval' => 2000,
+
+    /**
+     * Default Route to handle the AJAX request for polling for new notifications
+     * Cannot be changed dynamically.
+     */
+    'pollRouteUrl' => '/megaphone/poll',
+
+    /**
+     * Default Controller action to handle the AJAX request for polling for new notifications
+     */
+    'pollAction' => \MBarlow\Megaphone\Http\Controllers\MegaphonePollController::class,
 ];

--- a/resources/js/megaphone.js
+++ b/resources/js/megaphone.js
@@ -1,11 +1,15 @@
 document.addEventListener('alpine:init', () => {
     Alpine.data('notifications', (config={}) =>({
             unreadNotifications: 0,
-            unreadCount: 0,
             isShowingFilterSection: false,
             receivedUnreadNotifications: [],
+             // Used to store the expanded notifications. That is rather than just storing the notification ID, we store the whole notification object
+             // This is because we need to store the notification object for some manipulations.
+            receivedUnreadNotificationsExpanded: [],
             error: null,
             notificationComponentWireId: null,
+            isShowingFilterSection: false,
+            filterType: null,
 
             init() {
                 this.notificationComponentWireId = this.$el.getAttribute('wire:id');
@@ -14,12 +18,10 @@ document.addEventListener('alpine:init', () => {
                     setInterval(() => {
                         this.fetchNotifications();
                     }, config.pollInterval);
+
                 }else{
                     console.error('Poll interval not set. Notifications will not be polled for.');
                 }
-                this.$watch('receivedUnreadNotifications', (value) => {
-                    this.unreadCount = value.length ;
-                })
             },
 
             // Function to fetch new (unread) notifications from the server
@@ -50,7 +52,54 @@ document.addEventListener('alpine:init', () => {
                             this.error = data.error;
                         }
                     })
+                    .finally(() => {
+                        if(!this.areArraysInSync()){
+                            this.expandReceivedUnreadNotifications()
+                        }
+                    })
                     .catch(error => console.error('Error fetching notifications:', error));
+            },
+            // Convert the notification IDs to notification objects and store them in the expanded array
+            expandReceivedUnreadNotifications() {
+                return new Promise((resolve, reject) => {
+                    Promise.all(
+                        this.receivedUnreadNotifications.map(notificationId =>
+                            window.Livewire.find(this.notificationComponentWireId).findNotification(notificationId)
+                        )
+                    )
+                    .then(receivedUnreadNotificationsExpanded => {
+                        this.receivedUnreadNotificationsExpanded = receivedUnreadNotificationsExpanded;
+                        resolve(this.receivedUnreadNotificationsExpanded);
+                    })
+                    .catch(error => {
+                        console.error(error);
+                        reject(error);
+                    });
+                });
+            },
+
+            // Check if the receivedUnreadNotifications and receivedUnreadNotificationsExpanded arrays are in sync
+            // by looping through the unread notifications and checking if the notification ID is in the expanded array
+            // (i.e. the notification has been expanded)
+            areArraysInSync() {
+                return this.receivedUnreadNotifications.every(notification => {
+                    return this.receivedUnreadNotificationsExpanded.find(
+                        notificationExpanded => notificationExpanded.id === notification
+                    );
+                });
+            },
+
+            // Get the number of unread notifications
+
+            getUnreadCount(filterType = null){
+                if(filterType === null){
+                    return this.receivedUnreadNotifications.length;
+                }
+                const filteredUnreadNotifs = this.receivedUnreadNotificationsExpanded.filter(notification => {
+                    return notification.type === filterType;
+                })
+
+                return filteredUnreadNotifs.length;
             },
 
             markAsRead(id){
@@ -66,6 +115,23 @@ document.addEventListener('alpine:init', () => {
                 window.Livewire.find(this.notificationComponentWireId).call('markAllAsRead', notification);
                 window.Livewire.dispatch('refreshNotifications', {unread_notifications: []});
             },
+
+            shouldShowNotification(notification){
+                if(
+                    this.filterType === null ||
+                    this.filterType === notification.type
+                ){
+                    return true;
+                }
+                return false;
+
+            },
+
+            filterByType(type){
+                this.filterType = type;
+                this.isShowingFilterSection = false;
+                this.expandReceivedUnreadNotifications(); // essential to update the unread count
+            }
         })
     );
 })

--- a/resources/js/megaphone.js
+++ b/resources/js/megaphone.js
@@ -1,0 +1,61 @@
+document.addEventListener('alpine:init', () => {
+    Alpine.data('notifications', (config={}) =>({
+            unreadNotifications: 0,
+            unreadCount: 0,
+            isShowingFilterSection: false,
+            receivedUnreadNotifications: [],
+            notificationComponentWireId: null,
+
+            init() {
+                this.notificationComponentWireId = this.$el.getAttribute('wire:id');
+                this.fetchNotifications();
+                if(config.polling && config.pollInterval){
+                    setInterval(() => {
+                        this.fetchNotifications();
+                    }, config.pollInterval);
+                }else{
+                    console.error('Poll interval not set. Notifications will not be polled for.');
+                }
+                this.$watch('receivedUnreadNotifications', (value) => {
+                    this.unreadCount = value.length ;
+                })
+            },
+
+            // Function to fetch new (unread) notifications from the server
+            fetchNotifications() {
+                fetch(config.pollRouteUrl)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.unread_notifications) {
+                            // Handle new notifications
+                            data.unread_notifications.forEach(notification => {
+                                if(!this.receivedUnreadNotifications.includes(notification)){
+                                    window.Livewire.dispatch('refreshNotifications', {unread_notifications: data.unread_notifications});
+                                    this.receivedUnreadNotifications.push(notification);
+                                }
+                            })
+                        } else {
+                            // No new notifications
+                        }
+                    })
+                    .catch(error => console.error('Error fetching notifications:', error));
+            },
+
+            markAsRead(id){
+                if(this.receivedUnreadNotifications.includes(id)){
+                    this.receivedUnreadNotifications = this.receivedUnreadNotifications.filter(notification => notification !== id);
+                    document.getElementById(`unread-notification-${id}`).style.opacity = 0.5;
+                    window.Livewire.find(this.notificationComponentWireId).markAsRead(id);
+                }
+            },
+
+            markAllAsRead() {
+                this.receivedUnreadNotifications.forEach(notification => {
+                    window.Livewire.find(this.notificationComponentWireId).call('markAsRead', notification);
+                })
+                this.receivedUnreadNotifications = [];
+                window.Livewire.dispatch('refreshNotifications', {unread_notifications: this.unreadCount});
+            },
+        })
+    );
+})

--- a/resources/js/megaphone.js
+++ b/resources/js/megaphone.js
@@ -62,11 +62,9 @@ document.addEventListener('alpine:init', () => {
             },
 
             markAllAsRead() {
-                this.receivedUnreadNotifications.forEach(notification => {
-                    window.Livewire.find(this.notificationComponentWireId).call('markAsRead', notification);
-                })
                 this.receivedUnreadNotifications = [];
-                window.Livewire.dispatch('refreshNotifications', {unread_notifications: this.unreadCount});
+                window.Livewire.find(this.notificationComponentWireId).call('markAllAsRead', notification);
+                window.Livewire.dispatch('refreshNotifications', {unread_notifications: []});
             },
         })
     );

--- a/resources/views/icon.blade.php
+++ b/resources/views/icon.blade.php
@@ -1,6 +1,6 @@
 <button type="button"
         aria-label="show notifications"
-        class="dark:text-slate-400 sm:mt-0 mt-1 font-sans text-gray-900 border-none"
+        class="dark:text-slate-400 sm:mt-0 mt-1 font-sans text-gray-600 border-none"
         @click="open = true"
 >
     <span class="sr-only">Show Notifications</span>
@@ -8,7 +8,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
     </svg>
 
-    <div x-show="getUnreadCount() > 0">
+    <div x-cloak x-show="getUnreadCount() > 0">
         @if($showCount)
             <span
             x-text="getUnreadCount()"

--- a/resources/views/icon.blade.php
+++ b/resources/views/icon.blade.php
@@ -1,19 +1,21 @@
 <button type="button"
         aria-label="show notifications"
-        class="font-sans text-gray-900"
+        class="dark:text-slate-400 sm:mt-0 mt-1 font-sans text-gray-900 border-none"
         @click="open = true"
 >
     <span class="sr-only">Show Notifications</span>
-    <svg class="h-full w-full fill-black dark:fill-white" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <svg class="fill-none sm:w-8 sm:h-8 w-6 h-6" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
     </svg>
-    @if ($unread->count() > 0)
+
+    <div x-show="unreadCount > 0">
         @if($showCount)
-            <span aria-label="unread count" class="absolute top-0 left-0 aspect-square max-h-fit rounded-full border-2 bg-red-500 px-1.5 shadow leading-5 text-white font-semibold text-xs">
-                {{ $unread->count() }}
+            <span
+            x-text="unreadCount"
+            aria-label="unread count" class="aspect-w-1 aspect-h-1 max-h-fit absolute top-0 left-0 flex items-center justify-center px-1 text-xs font-semibold leading-5 text-white bg-red-500 rounded-full shadow" style="font-size: 0.7rem; width: 1rem; height: 1rem;">
             </span>
         @else
-            <span aria-label="has unread notifications" class="absolute top-0 left-0 aspect-square h-2/5 rounded-full bg-red-500 shadow">
+            <span aria-label="has unread notifications" class="aspect-square h-2/5 absolute top-0 left-0 bg-red-500 rounded-full shadow" style="width: 0.4rem; height: 0.4rem;"></span>
         @endif
-    @endif
+    </div>
 </button>

--- a/resources/views/icon.blade.php
+++ b/resources/views/icon.blade.php
@@ -8,10 +8,10 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
     </svg>
 
-    <div x-show="unreadCount > 0">
+    <div x-show="getUnreadCount() > 0">
         @if($showCount)
             <span
-            x-text="unreadCount"
+            x-text="getUnreadCount()"
             aria-label="unread count" class="aspect-w-1 aspect-h-1 max-h-fit absolute top-0 left-0 flex items-center justify-center px-1 text-xs font-semibold leading-5 text-white bg-red-500 rounded-full shadow" style="font-size: 0.7rem; width: 1rem; height: 1rem;">
             </span>
         @else

--- a/resources/views/megaphone.blade.php
+++ b/resources/views/megaphone.blade.php
@@ -1,6 +1,8 @@
 <div class="megaphone">
     <div class="relative w-12 h-12" x-data="{ open: false }">
         @include('megaphone::icon')
-        @include('megaphone::popout')
+        @teleport('body')
+            @include('megaphone::popout')
+        @endteleport
     </div>
 </div>

--- a/resources/views/megaphone.blade.php
+++ b/resources/views/megaphone.blade.php
@@ -3,6 +3,11 @@
         'polling' => $polling,
         'pollInterval' => $pollInterval,
         'pollRouteUrl' => $pollRouteUrl,
+        'notifiable' => base64_encode(json_encode([
+            'id' => $notifiable->getKey(),
+            'model' => $notifiable->getMorphClass(),
+        ])), // base 64 encoded to ensure that it can be safely passed as a url parameter
+        'csrfToken' => csrf_token(),
     ])
 )">
     <div class="relative w-12 h-12 mt-4">

--- a/resources/views/megaphone.blade.php
+++ b/resources/views/megaphone.blade.php
@@ -1,5 +1,11 @@
-<div class="megaphone">
-    <div class="relative w-12 h-12" x-data="{ open: false }">
+<div class="megaphone" x-data="notifications(
+    @js([
+        'polling' => $polling,
+        'pollInterval' => $pollInterval,
+        'pollRouteUrl' => $pollRouteUrl,
+    ])
+)">
+    <div class="relative w-12 h-12 mt-4">
         @include('megaphone::icon')
         @teleport('body')
             @include('megaphone::popout')

--- a/resources/views/megaphone.blade.php
+++ b/resources/views/megaphone.blade.php
@@ -7,6 +7,7 @@
             'id' => $notifiable->getKey(),
             'model' => $notifiable->getMorphClass(),
         ])), // base 64 encoded to ensure that it can be safely passed as a url parameter
+        'showTitleCountInPageTitle' => $showTitleCountInPageTitle,
         'csrfToken' => csrf_token(),
     ])
 )">

--- a/resources/views/popout.blade.php
+++ b/resources/views/popout.blade.php
@@ -5,12 +5,8 @@
         <div class="fixed top-0 left-0 z-0 w-full h-full" @click="open = false"></div>
         <div class="2xl:w-4/12 sm:w-2/5 bg-gray-50 dark:bg-slate-800 absolute right-0 z-30 w-full h-screen p-4 pt-8 overflow-y-auto shadow-md">
 
-            <button role="button" aria-label="close modal" class="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 rounded-md cursor-pointer" @click="open = false">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M18 6L6 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-                    <path d="M6 6L18 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </button>
+            <button class="right-0" role="button" aria-label="close modal" @click="open = false"><x-icon name="x-mark" class="w-6 h-6 text-gray-500" /></button>
+
 
             <div class="flex items-center justify-between">
                 <p tabindex="0" class="focus:outline-none dark:text-gray-400 text-2xl font-semibold leading-6 text-gray-800">Notifications</p>
@@ -23,62 +19,61 @@
                 <hr class="w-full">
             </div>
 
-            <div x-show="unreadCount > 0" >
-                <div class="dark:border-slate-600 flex justify-between pt-8 pb-2 border-b border-gray-300">
-                    <h2 tabindex="0" class="focus:outline-none dark:text-slate-300 text-sm leading-normal text-gray-600">
-                        Unread Notifications
-                    </h2>
+            <div x-cloak x-show="!isShowingFilterSection">
+                <div x-show="unreadCount > 0" >
+                    <div class="dark:border-slate-600 flex justify-between pt-8 pb-2 border-b border-gray-300">
+                        <h2 tabindex="0" class="focus:outline-none dark:text-slate-300 text-sm leading-normal text-gray-600">
+                            Unread Notifications
+                        </h2>
 
-                    <!----- Mark all as read button ----->
-                    <h2 x-on:click="markAllAsRead" wire-id="{{ $this->getId() }}" tabindex="0" class="focus:outline-none dark:text-slate-400 float-right text-xs text-sm leading-normal text-gray-500">
-                        Mark all as read
-                    </h2>
+                        <!----- Mark all as read button ----->
+                        <h2 x-on:click="markAllAsRead" wire-id="{{ $this->getId() }}" tabindex="0" class="focus:outline-none dark:text-slate-400 float-right text-xs text-sm leading-normal text-gray-500">
+                            Mark all as read
+                        </h2>
+                    </div>
+
+                    <!----- Unread Notifications ----->
+                    @foreach ($unread as $announcement)
+                        @php $id = $announcement->id; @endphp
+                        <div id="unread-notification-{{ $id }}">
+                            <div class="w-full p-3 mt-4 bg-white  dark:bg-slate-900 border-none  rounded flex flex-shrink-0 {{ $announcement->read_at === null ? "drop-shadow shadow border" : ""  }}">
+                                <x-megaphone::display :notification="$announcement"></x-megaphone::display>
+
+                                @if($announcement->read_at === null)
+                                    <button role="button" aria-label="Mark as Read" class="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 w-6 h-6 rounded-md cursor-pointer"
+                                            x-on:click="markAsRead('{{ $id }}')"
+
+                                    >
+                                    <x-icon name="x-mark" class="w-6 h-6 text-gray-500" />
+                                    </button>
+                                @endif
+                            </div>
+                        </div>
+                    @endforeach
                 </div>
 
-                <!----- Unread Notifications ----->
-                @foreach ($unread as $announcement)
-                    @php $id = $announcement->id; @endphp
-                    <div id="unread-notification-{{ $id }}">
-                        <div class="w-full p-3 mt-4 bg-white  dark:bg-slate-900 border-none  rounded flex flex-shrink-0 {{ $announcement->read_at === null ? "drop-shadow shadow border" : ""  }}">
-                            <x-megaphone::display :notification="$announcement"></x-megaphone::display>
-
-                            @if($announcement->read_at === null)
-                                <button role="button" aria-label="Mark as Read" class="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 w-6 h-6 rounded-md cursor-pointer"
-                                        x-on:click="markAsRead('{{ $id }}')"
-
-                                >
-                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <path d="M18 6L6 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-                                        <path d="M6 6L18 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-                                    </svg>
-                                </button>
-                            @endif
-                        </div>
+                <!--------------- Previous Notifications ----------------->
+                @if ($announcements->count() > 0)
+                    <h2 tabindex="0" class="focus:outline-none dark:border-slate-600 dark:text-slate-300 pt-8 pb-2 text-sm leading-normal text-gray-600 border-b border-gray-300">
+                        Previous Notifications
+                    </h2>
+                @endif
+                @foreach ($announcements as $announcement)
+                    <div class="w-full p-3   dark:bg-slate-800 dark:border-slate-700 border-b border-gray-300 rounded flex flex-shrink-0 {{ $announcement->read_at === null ? "drop-shadow shadow border" : ""  }}">
+                        <x-megaphone::display :notification="$announcement"></x-megaphone::display>
                     </div>
                 @endforeach
+
+                @if ($unread->count() === 0 && $announcements->count() === 0)
+                    <div class="flex items-center justify-between">
+                        <hr class="w-full">
+                        <p tabindex="0" class="focus:outline-none flex flex-shrink-0 px-3 py-16 text-sm leading-normal text-gray-500">
+                            No new announcements
+                        </p>
+                        <hr class="w-full">
+                    </div>
+                @endif
             </div>
-
-            <!--------------- Previous Notifications ----------------->
-            @if ($announcements->count() > 0)
-                <h2 tabindex="0" class="focus:outline-none dark:border-slate-600 dark:text-slate-300 pt-8 pb-2 text-sm leading-normal text-gray-600 border-b border-gray-300">
-                    Previous Notifications
-                </h2>
-            @endif
-            @foreach ($announcements as $announcement)
-                <div class="w-full p-3   dark:bg-slate-800 dark:border-slate-700 border-b border-gray-300 rounded flex flex-shrink-0 {{ $announcement->read_at === null ? "drop-shadow shadow border" : ""  }}">
-                    <x-megaphone::display :notification="$announcement"></x-megaphone::display>
-                </div>
-            @endforeach
-
-            @if ($unread->count() === 0 && $announcements->count() === 0)
-                <div class="flex items-center justify-between">
-                    <hr class="w-full">
-                    <p tabindex="0" class="focus:outline-none flex flex-shrink-0 px-3 py-16 text-sm leading-normal text-gray-500">
-                        No new announcements
-                    </p>
-                    <hr class="w-full">
-                </div>
-            @endif
 
         </div>
 

--- a/resources/views/popout.blade.php
+++ b/resources/views/popout.blade.php
@@ -28,6 +28,11 @@
                     <h2 tabindex="0" class="focus:outline-none dark:text-slate-300 text-sm leading-normal text-gray-600">
                         Unread Notifications
                     </h2>
+
+                    <!----- Mark all as read button ----->
+                    <h2 x-on:click="markAllAsRead" wire-id="{{ $this->getId() }}" tabindex="0" class="focus:outline-none dark:text-slate-400 float-right text-xs text-sm leading-normal text-gray-500">
+                        Mark all as read
+                    </h2>
                 </div>
 
                 <!----- Unread Notifications ----->

--- a/resources/views/popout.blade.php
+++ b/resources/views/popout.blade.php
@@ -1,61 +1,78 @@
-<div x-cloak x-show="open" @click.outside="open = false" class="w-full fixed z-50 top-0 right-0 h-full overflow-x-hidden transform translate-x-0 transition ease-in-out duration-700" id="notification">
-    <div class="fixed w-full h-full top-0 left-0 z-0" @click="open = false"></div>
 
-    <div class="2xl:w-4/12 bg-gray-50 shadow-md h-screen overflow-y-auto p-8 pt-3 absolute right-0 z-30">
-        <div class="flex items-center justify-between">
-            <p tabindex="0" class="focus:outline-none text-2xl font-semibold leading-6 text-gray-800">Notifications</p>
+<!--------------------------------- Notification Popout ------------------------------------->
+<div>
+    <div x-cloak x-show="open" x-transition   class="fixed top-0 right-0 z-50 w-full h-full overflow-x-hidden transition duration-700 ease-in-out transform translate-x-0" id="notification">
+        <div class="fixed top-0 left-0 z-0 w-full h-full" @click="open = false"></div>
+        <div class="2xl:w-4/12 sm:w-2/5 bg-gray-50 dark:bg-slate-800 absolute right-0 z-30 w-full h-screen p-4 pt-8 overflow-y-auto shadow-md">
+
             <button role="button" aria-label="close modal" class="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 rounded-md cursor-pointer" @click="open = false">
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M18 6L6 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
                     <path d="M6 6L18 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
                 </svg>
             </button>
-        </div>
 
-        @if ($unread->count() > 0)
-            <h2 tabindex="0" class="focus:outline-none text-sm leading-normal pt-8 border-b pb-2 border-gray-300 text-gray-600">
-                Unread Notifications
-            </h2>
+            <div class="flex items-center justify-between">
+                <p tabindex="0" class="focus:outline-none dark:text-gray-400 text-2xl font-semibold leading-6 text-gray-800">Notifications</p>
+            </div>
 
-            @foreach ($unread as $announcement)
-                <div class="w-full p-3 mt-4 bg-white rounded flex flex-shrink-0 {{ $announcement->read_at === null ? "drop-shadow shadow border" : ""  }}">
-                    <x-megaphone::display :notification="$announcement"></x-megaphone::display>
-
-                    @if($announcement->read_at === null)
-                        <button role="button" aria-label="Mark as Read" class="w-6 h-6 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 rounded-md cursor-pointer"
-                                x-on:click="$wire.markAsRead('{{ $announcement->id }}')"
-                        >
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M18 6L6 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-                                <path d="M6 6L18 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
-                            </svg>
-                        </button>
-                    @endif
+            <div x-show="unreadCount > 0" >
+                <div class="dark:border-slate-600 flex justify-between pt-8 pb-2 border-b border-gray-300">
+                    <h2 tabindex="0" class="focus:outline-none dark:text-slate-300 text-sm leading-normal text-gray-600">
+                        Unread Notifications
+                    </h2>
                 </div>
-            @endforeach
 
+                <!----- Unread Notifications ----->
+                @foreach ($unread as $announcement)
+                    @php $id = $announcement->id; @endphp
+                    <div id="unread-notification-{{ $id }}">
+                        <div class="w-full p-3 mt-4 bg-white  dark:bg-slate-900 border-none  rounded flex flex-shrink-0 {{ $announcement->read_at === null ? "drop-shadow shadow border" : ""  }}">
+                            <x-megaphone::display :notification="$announcement"></x-megaphone::display>
+
+                            @if($announcement->read_at === null)
+                                <button role="button" aria-label="Mark as Read" class="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 w-6 h-6 rounded-md cursor-pointer"
+                                        x-on:click="markAsRead('{{ $id }}')"
+
+                                >
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M18 6L6 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
+                                        <path d="M6 6L18 18" stroke="#4B5563" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" />
+                                    </svg>
+                                </button>
+                            @endif
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+
+            <!--------------- Previous Notifications ----------------->
             @if ($announcements->count() > 0)
-                <h2 tabindex="0" class="focus:outline-none text-sm leading-normal pt-8 border-b pb-2 border-gray-300 text-gray-600">
+                <h2 tabindex="0" class="focus:outline-none dark:border-slate-600 dark:text-slate-300 pt-8 pb-2 text-sm leading-normal text-gray-600 border-b border-gray-300">
                     Previous Notifications
                 </h2>
             @endif
-        @endif
+            @foreach ($announcements as $announcement)
+                <div class="w-full p-3   dark:bg-slate-800 dark:border-slate-700 border-b border-gray-300 rounded flex flex-shrink-0 {{ $announcement->read_at === null ? "drop-shadow shadow border" : ""  }}">
+                    <x-megaphone::display :notification="$announcement"></x-megaphone::display>
+                </div>
+            @endforeach
 
-        @foreach ($announcements as $announcement)
-            <div class="w-full p-3 mt-4 bg-white rounded flex flex-shrink-0 {{ $announcement->read_at === null ? "drop-shadow shadow border" : ""  }}">
-                <x-megaphone::display :notification="$announcement"></x-megaphone::display>
-            </div>
-        @endforeach
+            @if ($unread->count() === 0 && $announcements->count() === 0)
+                <div class="flex items-center justify-between">
+                    <hr class="w-full">
+                    <p tabindex="0" class="focus:outline-none flex flex-shrink-0 px-3 py-16 text-sm leading-normal text-gray-500">
+                        No new announcements
+                    </p>
+                    <hr class="w-full">
+                </div>
+            @endif
 
-        @if ($unread->count() === 0 && $announcements->count() === 0)
-            <div class="flex items-center justify-between">
-                <hr class="w-full">
-                <p tabindex="0" class="focus:outline-none text-sm flex flex-shrink-0 leading-normal px-3 py-16 text-gray-500">
-                    No new announcements
-                </p>
-                <hr class="w-full">
-            </div>
-        @endif
+        </div>
+
+
     </div>
-</div>
 
+    <!-- Background Overlay, when the sidebar is open -->
+    <div x-show="open" x-cloak  class="fixed inset-0 z-30 block bg-gray-800 opacity-75">..</div>
+</div>

--- a/resources/views/popout.blade.php
+++ b/resources/views/popout.blade.php
@@ -16,6 +16,13 @@
                 <p tabindex="0" class="focus:outline-none dark:text-gray-400 text-2xl font-semibold leading-6 text-gray-800">Notifications</p>
             </div>
 
+            <!----------------- Error Message ----------------->
+            <div x-show="error" class="flex items-center justify-between">
+                <hr class="w-full">
+                <p tabindex="0" x-text="error" class="focus:outline-none flex flex-shrink-0 px-3 py-16 text-sm leading-normal text-red-500"></p>
+                <hr class="w-full">
+            </div>
+
             <div x-show="unreadCount > 0" >
                 <div class="dark:border-slate-600 flex justify-between pt-8 pb-2 border-b border-gray-300">
                     <h2 tabindex="0" class="focus:outline-none dark:text-slate-300 text-sm leading-normal text-gray-600">

--- a/resources/views/popout.blade.php
+++ b/resources/views/popout.blade.php
@@ -14,6 +14,7 @@
                 <button x-on:click="isShowingFilterSection = !isShowingFilterSection" x-show="isShowingFilterSection"><x-icon name="bars-4" class="w-6 h-6 text-gray-500" /></button>
             </div>
 
+            <hr class="my-4 dark:border-gray-600 border-gray-300">
             <!----------------- Error Message ----------------->
             <div x-show="error" class="flex items-center justify-between">
                 <hr class="w-full">
@@ -79,8 +80,8 @@
 
             <!---------------- Filter Section ----------------->
             <div x-cloak x-show="isShowingFilterSection">
-                <div class="flex items-center justify-between">
-                    <p tabindex="0" class="focus:outline-none dark:text-gray-400 text-2xl font-semibold leading-6 text-gray-800">Filter</p>
+                <div class="flex items-center justify-between mt-4">
+                    <p tabindex="0" class="focus:outline-none dark:text-gray-400 text-xl font-semibold leading-6 text-gray-800">Filter</p>
                 </div>
 
                 <div class="flex flex-col mt-6">
@@ -90,9 +91,9 @@
                                 Filter by Type
                             </h2>
                             <div class="flex flex-col mt-2">
-                                <div class="dark:hover:bg-slate-900 flex justify-between p-2 border-b border-gray-700"
+                                <div class="dark:hover:bg-slate-900 flex justify-between p-2 border-b hover:bg-slate-100 border-gray-300 dark:border-gray-700"
                                     x-on:click="filterByType(null)"
-                                    x-bind:class=" !filterType ? 'border-l-green-500 dark:bg-slate-900 border-l-4' : ''"
+                                    x-bind:class=" !filterType ? 'border-l-primary-500 dark:border-l-primary-700 bg-slate-200 dark:bg-slate-900 border-l-4' : ''"
                                 >
                                     <span class="dark:text-gray-400 ml-2 text-sm leading-normal">All </span>
                                     @if($this->unread->count())
@@ -106,8 +107,9 @@
                                         // kinda a hack to get the name of the notification class
                                         $name = getNotificationInstance($announcementType->type, $announcements->first())->name();
                                     @endphp
-                                    <div x-bind:class="filterType === @js($type) ? 'dark:bg-slate-900 border-l-green-500 border-l-4' : ''"
-                                        class="dark:hover:bg-slate-900 dark:bg-slate-800 flex justify-between p-2 border-b border-gray-700" x-on:click="filterByType(@js($type))">
+                                    <div x-bind:class="filterType === @js($type) ? 'border-l-primary-500 dark:border-l-primary-700 bg-slate-200 dark:bg-slate-900 border-l-4' : ''"
+                                        class="dark:hover:bg-slate-900 flex justify-between p-2 border-b hover:bg-slate-100 border-gray-300 dark:border-gray-700"
+                                        x-on:click="filterByType(@js($type))">
                                         <span class="dark:text-gray-400 ml-2 text-sm leading-normal">{{ $name  }}</span>
 
                                         <span x-show="getUnreadCount('{{ addcslashes($type, '\\"\'/') }}');"

--- a/resources/views/types/base.blade.php
+++ b/resources/views/types/base.blade.php
@@ -1,10 +1,10 @@
-<div tabindex="0" aria-label="group icon" role="img" class="focus:outline-none w-8 h-8 border rounded-full border-gray-200 flex flex-shrink-0 items-center justify-center">
+<div tabindex="0" aria-label="group icon" role="img" class="focus:outline-none w-8 h-8 border rounded-full dark:border-gray-700 border-gray-200 flex flex-shrink-0 items-center justify-center">
     {!! $icon ?? '' !!}
 </div>
 <div class="pl-3 w-full">
     <div class="items-center justify-between w-full pr-2">
         <p class="block w-full focus:outline-none text-sm leading-none my-0">
-            <span class="text-indigo-700 font-bold">
+            <span class="text-primary-700 dark:text-gray-300 font-bold">
                 @if(! empty($announcement['link']))
                     <a href="{{ $announcement['link'] }}">
                 @endif
@@ -14,7 +14,7 @@
                 @endif
             </span>
         </p>
-        <p class="block w-full focus:outline-none text-sm leading-none">
+        <p class="block w-full focus:outline-none text-sm text-gray-700 leading-none  dark:text-gray-400">
             {{ $announcement['body'] }}
         </p>
     </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,9 @@
+<?php
+use Illuminate\Support\Facades\Route;
+
+// Polling only for the current logged in user
+Route::get(config('megaphone.pollRouteUrl'), [config('megaphone.pollAction'),'__invoke'])->name('megaphone.poll')->middleware('web');
+
+// TODO: Add a route to allow polling for any model that has the HasMegaphone trait without introducing a security risk.
+// e.g /megaphone/poll/{model}/{id} ... or something like that
+// would be likely for debugging purposes only

--- a/src/HasMegaphone.php
+++ b/src/HasMegaphone.php
@@ -2,6 +2,7 @@
 
 namespace MBarlow\Megaphone;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait HasMegaphone
@@ -13,5 +14,10 @@ trait HasMegaphone
                 'type',
                 getMegaphoneTypes()
             );
+    }
+
+    public function canAccessNotifications(Model $notifiable): bool
+    {
+        return $this->is($notifiable) || $this->can(config('megaphone.access-notifications-permission-name'), $notifiable);
     }
 }

--- a/src/Http/Controllers/MegaphonePollController.php
+++ b/src/Http/Controllers/MegaphonePollController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MBarlow\Megaphone\Http\Controllers;
+
+class MegaphonePollController
+{
+
+    public function getNotifiable()
+    {
+        if(!auth()->check()) return abort(403, 'Login required');
+
+        // TODO: This is a hack to get the current user.  It should be passed in as a parameter.
+        // However, simply passing it as a parameter would lead to a security hole, as the user could
+        // pass in any user ID they wanted.  So, we need to pass in the user ID and then check that
+        // the user ID matches the current user, or at least that the current user has permission
+        // to view the notifications for the user ID passed in.
+        return auth()->user();
+    }
+
+    public function __invoke()
+    {
+        $unreadNotifications = $this->getNotifiable()->unreadNotifications->pluck('id');
+        return response()->json([
+            'unread_notifications' => $unreadNotifications->count() ? $unreadNotifications : null
+        ]);
+    }
+}

--- a/src/Http/Controllers/MegaphonePollController_v2.php
+++ b/src/Http/Controllers/MegaphonePollController_v2.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MBarlow\Megaphone\Http\Controllers;
+
+use Illuminate\Http\Request;
+use MBarlow\Megaphone\Models\Notification;
+
+class MegaphonePollController
+{
+
+    public function getNotifiable()
+    {
+        // TODO: This is a hack to get the current user.  It should be passed in as a parameter.
+
+        return auth()->user();
+    }
+
+    public function __invoke(Request $request)
+    {
+        //dd(auth()->user(), $request->user());
+        if(!auth()->check()) return abort(403, 'Login required');
+
+        $filterType = request()->get('filter_type');
+
+        $unreadNotifications = $this->getNotifiable()->unreadNotifications->when($filterType, function($query) use($filterType){
+            return $query->where('type', $filterType);
+        })->pluck('id');
+        if($unreadNotifications->count() > 0){
+            return response()->json([
+                'unread_notifications' => $unreadNotifications
+            ]);
+        }
+        else{
+            return response()->json([
+                'unread_notifications' => null
+            ]);
+        }
+    }
+}

--- a/src/Livewire/Megaphone.php
+++ b/src/Livewire/Megaphone.php
@@ -113,4 +113,10 @@ class Megaphone extends Component
         $notification->markAsRead();
         $this->loadAnnouncements($this->getNotifiable());
     }
+
+    public function markAllAsRead()
+    {
+        $this->notifiable->unreadNotifications->markAsRead();
+        $this->loadAnnouncements($this->getNotifiable());
+    }
 }

--- a/src/Livewire/Megaphone.php
+++ b/src/Livewire/Megaphone.php
@@ -25,6 +25,8 @@ class Megaphone extends Component
 
     public $showCount;
 
+    public bool $showTitleCountInPageTitle = true;
+
     /**
      * The keys that the annoucements should be have when displayed (serialised from the database and passed to the view)
      * (This is to prevent the entire model being passed to the view)

--- a/src/Livewire/Megaphone.php
+++ b/src/Livewire/Megaphone.php
@@ -2,14 +2,20 @@
 
 namespace MBarlow\Megaphone\Livewire;
 
-use Illuminate\Http\Request;
-use Illuminate\Notifications\DatabaseNotification;
-use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Illuminate\Http\Request;
+use Livewire\Attributes\Locked;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\DatabaseNotification;
 
 class Megaphone extends Component
 {
-    public $notifiableId;
+    /**
+     * The model that whose notifications should be displayed
+     *
+     * @var Model
+     */
+    public ?Model $notifiable = null;
 
     public $announcements;
 
@@ -50,8 +56,8 @@ class Megaphone extends Component
 
     public function initialize(Request $request)
     {
-        if (empty($this->notifiableId) && $request->user() !== null) {
-            $this->notifiableId = $request->user()->id;
+        if (empty($this->notifiable) && $request->user() !== null) {
+            $this->notifiable = $request->user();
         }
 
         $this->loadAnnouncements($this->getNotifiable());
@@ -68,7 +74,7 @@ class Megaphone extends Component
 
     public function getNotifiable()
     {
-        return config('megaphone.model')::find($this->notifiableId);
+        return $this->notifiable;
     }
 
     public function loadAnnouncements($notifiable)
@@ -87,6 +93,18 @@ class Megaphone extends Component
     public function render()
     {
         $this->initialize(request());
+
+        if(!$this->notifiable) {
+            return  <<<HTML
+                <div class="flex items-center justify-center h-full">
+                    <div class="text-center">
+                        <h1 class="text-3xl font-bold text-gray-900">Megaphone</h1>
+                        <p class="mt-2 text-sm text-gray-500">Please set the <code>notifiable</code> property on the Megaphone component.</p>
+                    </div>
+                </div>
+            HTML;
+        }
+
         return view('megaphone::megaphone');
     }
 

--- a/src/Livewire/Megaphone.php
+++ b/src/Livewire/Megaphone.php
@@ -19,9 +19,27 @@ class Megaphone extends Component
 
     public $announcements;
 
+    public $allAnnouncementsTypes;
+
     public $unread;
 
     public $showCount;
+
+    /**
+     * The keys that the annoucements should be have when displayed (serialised from the database and passed to the view)
+     * (This is to prevent the entire model being passed to the view)
+     * This can be modified to include any additional fields you want to display
+     * @var array
+     */
+    #[Locked]
+    public $keys = [
+        'id',
+        'type',
+        // 'read_at',
+        // 'created_at',
+        // 'updated_at',
+    ];
+
 
     /**
      * Whether to poll for new notifications
@@ -86,8 +104,23 @@ class Megaphone extends Component
         }
 
         $announcements = $notifiable->announcements()->get();
+
         $this->unread = $announcements->whereNull('read_at');
         $this->announcements = $announcements->whereNotNull('read_at');
+
+        $this->allAnnouncementsTypes = $notifiable->announcements()->select('type')->distinct()->get();
+
+    }
+
+    public function markAsUnread(DatabaseNotification $notification)
+    {
+        $notification->markAsUnread();
+        $this->loadAnnouncements($this->getNotifiable());
+    }
+
+    public function findNotification($id)
+    {
+        return $this->notifiable->announcements()->where('id', $id)->first()->only($this->keys);
     }
 
     public function render()

--- a/src/MegaphoneServiceProvider.php
+++ b/src/MegaphoneServiceProvider.php
@@ -54,5 +54,11 @@ class MegaphoneServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../resources/views' => resource_path('views/vendor/megaphone'),
         ], 'megaphone-views');
+
+        // Register routes
+        $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
+
+        // Register Controller
+        $this->app->make('MBarlow\Megaphone\Http\Controllers\MegaphonePollController');
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -22,3 +22,10 @@ if (! function_exists('getMegaphoneAdminTypes')) {
         return getMegaphoneTypes();
     }
 }
+
+if(! function_exists('getNotificationInstance')){
+    function getNotificationInstance($className, $params)
+    {
+        return (new $className($params['title'], $params['body']));
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,5 @@
+Filtering system
+<x-icon> rather than svg icons
+Fix critical security bug:
+   window.Livewire.find("d1A99HsopOlhz3EvZ8y0").notifiableId = 2
+   window.Livewire.find("d1A99HsopOlhz3EvZ8y0").call('loadAnnouncements',null)


### PR DESCRIPTION
Occasionally, the megaphone popout might appear under the body and navbar, depending on the structure of the navbar, usually if the navbar is fixed/sticky or something. Simply changing the `z-index` does not work.

Luckily, livewire v3 provided a simple functionality to fix it, `@teleport`

https://livewire.laravel.com/docs/teleport


@mikebarlow If you are wondering, I deleted the previous fork, so the previous exact pull request was deleted as well.