### PR TITLE
Fix: clicking on link marks notification as read

### DIFF
--- a/resources/views/components/notification/link.blade.php
+++ b/resources/views/components/notification/link.blade.php
@@ -1,12 +1,14 @@
 @props([
     'parentClass' => 'mt-2 text-right focus:outline-none text-xs leading-3 pt-1 pb-2 right-0',
     'class' => 'cursor-pointer no-underline bg-gray-100 text-gray-800 rounded-md border border-gray-300 p-2 hover:bg-gray-300',
-    'link', 'newWindow', 'linkText',
+    'link', 'newWindow', 'linkText', 'notificationID'
 ])
 
 @if(! empty($link))
     <p class="{{ $parentClass }}">
-        <a href="{{ $link }}" {{ ! empty($newWindow) ? ' target="_blank"' : '' }} class="{{ $class }}">
+        <a href="{{ $link }}" {{ ! empty($newWindow) ? ' target="_blank"' : '' }} class="{{ $class }}"
+           @click="$dispatch('notification-link-clicked', { notification: '{{ $notificationID }}' })"
+           >
             {{ ! empty($linkText) ? $linkText : 'View' }}
         </a>
     </p>

--- a/resources/views/types/general.blade.php
+++ b/resources/views/types/general.blade.php
@@ -15,6 +15,7 @@
 
     <x-slot:link>
         <x-megaphone::notification.link
+            :notificationID="$announcement['id']"
             :link="$announcement['link']"
             :newWindow="$announcement['linkNewWindow']"
             :linkText="$announcement['linkText']"

--- a/resources/views/types/important.blade.php
+++ b/resources/views/types/important.blade.php
@@ -15,6 +15,7 @@
 
     <x-slot:link>
         <x-megaphone::notification.link
+            :notificationID="$announcement['id']"
             :link="$announcement['link']"
             :newWindow="$announcement['linkNewWindow']"
             :linkText="$announcement['linkText']"

--- a/resources/views/types/new-feature.blade.php
+++ b/resources/views/types/new-feature.blade.php
@@ -15,6 +15,7 @@
 
     <x-slot:link>
         <x-megaphone::notification.link
+            :notificationID="$announcement['id']"
             :link="$announcement['link']"
             :newWindow="$announcement['linkNewWindow']"
             :linkText="$announcement['linkText']"

--- a/src/Components/Display.php
+++ b/src/Components/Display.php
@@ -41,6 +41,8 @@ class Display extends Component
             'created_at' => $this->notification->created_at,
         ];
 
+        $params['announcement']['id'] = $this->notification->id;
+
         $customTypes = config('megaphone.customTypes');
 
         if (! empty($customTypes[$this->notification->type])) {

--- a/src/Livewire/Megaphone.php
+++ b/src/Livewire/Megaphone.php
@@ -16,6 +16,10 @@ class Megaphone extends Component
 
     public $showCount;
 
+    protected $listeners = [
+        'notification-link-clicked' => 'markAsRead',
+    ];
+
     public $rules = [
         'unread' => 'required',
         'announcements' => 'required',

--- a/tests/Setup/views/custom-type.blade.php
+++ b/tests/Setup/views/custom-type.blade.php
@@ -17,6 +17,7 @@
 
     <x-slot:link>
         <x-megaphone::notification.link
+                :notificationID="$announcement['id']"
                 :link="$announcement['link']"
                 :newWindow="$announcement['linkNewWindow']"
                 :linkText="$announcement['linkText']"


### PR DESCRIPTION
This PR fixes issue #44 

To do this the notification ID is passed into the views and an alpine @click event is attached to the link to dispatch a Livewire event which in turn marks the notification as read.